### PR TITLE
RDKEMW-11484: Fix the EntServices-connectivity to support R5.3

### DIFF
--- a/Bluetooth/Module.h
+++ b/Bluetooth/Module.h
@@ -22,8 +22,8 @@
 #define MODULE_NAME Plugin_Bluetooth
 #endif
 
+#include <core/core.h>
 #include <plugins/plugins.h>
-#include <tracing/tracing.h>
 
 #undef EXTERNAL
 #define EXTERNAL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@
 
 cmake_minimum_required(VERSION 3.3)
 
-find_package(WPEFramework)
+find_package(Thunder NAMES WPEFramework Thunder)
 
 # All packages that did not deliver a CMake Find script (and some deprecated scripts that need to be removed)
 # are located in the cmake directory. Include it in the search.

--- a/helpers/UtilsController.h
+++ b/helpers/UtilsController.h
@@ -158,11 +158,7 @@ namespace Utils
         return thunderClient;
     }
 
-#ifndef USE_THUNDER_R4
-    class Job : public Core::IDispatchType<void>
-#else
     class Job : public Core::IDispatch
-#endif /* USE_THUNDER_R4 */
     {
     public:
         Job(std::function<void()> work)
@@ -202,23 +198,18 @@ namespace Utils
         uint32_t result = Core::ERROR_ASYNC_FAILED;
         Core::Event event(false, true);
 
-#ifndef USE_THUNDER_R4
-        Core::IWorkerPool::Instance().Submit(Core::ProxyType<Core::IDispatchType<void>>(Core::ProxyType<Job>::Create([&]()
-                                                                                                                     {
-#else
         Core::IWorkerPool::Instance().Submit(Core::ProxyType<Core::IDispatch>(Core::ProxyType<Job>::Create([&]()
-                                                                                                           {
-#endif /* USE_THUNDER_R4 */
-                    auto interface = shell->QueryInterfaceByCallsign<PluginHost::IShell>(callsign);
-                    if (interface == nullptr) {
-                        result = Core::ERROR_UNAVAILABLE;
-                        std::cout << "no IShell for " << callsign << std::endl;
-                    } else {
-                        result = interface->Activate(PluginHost::IShell::reason::REQUESTED);
-                        std::cout << "IShell activate status " << result << " for " << callsign << std::endl;
-                        interface->Release();
-                    }
-                    event.SetEvent(); })));
+        {
+            auto interface = shell->QueryInterfaceByCallsign<PluginHost::IShell>(callsign);
+            if (interface == nullptr) {
+                result = Core::ERROR_UNAVAILABLE;
+                 std::cout << "no IShell for " << callsign << std::endl;
+            } else {
+                result = interface->Activate(PluginHost::IShell::reason::REQUESTED);
+                std::cout << "IShell activate status " << result << " for " << callsign << std::endl;
+                interface->Release();
+            }
+            event.SetEvent(); })));
 
         event.Lock();
         return result;

--- a/helpers/UtilsJsonRpc.h
+++ b/helpers/UtilsJsonRpc.h
@@ -69,7 +69,6 @@
  * You should be capable of just using "Notify".
  */
 
-#if ((THUNDER_VERSION >= 4) && (THUNDER_VERSION_MINOR == 4))
 
 #define sendNotify(event,params) { \
     std::string json; \
@@ -85,22 +84,6 @@
     Notify(event,params); \
 }
 
-#else
-
-#define sendNotify(event,params) { \
-    std::string json; \
-    params.ToString(json); \
-    LOGINFO("Notify %s %s", event, json.c_str()); \
-    for (uint8_t i = 1; GetHandler(i); i++) GetHandler(i)->Notify(event,params); \
-}
-#define sendNotifyMaskParameters(event,params) { \
-    std::string json; \
-    params.ToString(json); \
-    LOGINFO("Notify %s <***>", event); \
-    for (uint8_t i = 1; GetHandler(i); i++) GetHandler(i)->Notify(event,params); \
-}
-
-#endif
 /**
  * DO NOT USE THIS.
  *


### PR DESCRIPTION
Reason for change: Added entservices-connectivity changes to support the Thunder R5.3
Test Procedure: please refer the ticket comments
Risks: Medium
version: patch
Signed-off-by: Thamim Razith Abbas Ali tabbas651@cable.comcast.com